### PR TITLE
Add AppArmor status check to Ubuntu hardening script

### DIFF
--- a/ubuntu_hardening.sh
+++ b/ubuntu_hardening.sh
@@ -65,6 +65,7 @@ PACKAGES=(
     "auditd"
     "acct"
     "sysstat"
+    "Apparmor-utils"
 )
 
 for package in "${PACKAGES[@]}"; do
@@ -128,6 +129,12 @@ chmod 700 /usr/bin/gcc /usr/bin/cc || echo "[WARNING] GCC not found. Skipping co
 
 # Run RKHunter installation and updates
 install_rkhunter
+
+# --- Added by Martin (Powered by ChatGPT) ---
+# AppArmor profile check
+echo "[*] Checking AppArmor status..."
+apparmor_status
+
 
 echo "[INFO] Security hardening completed successfully at $(date)."
 echo "Check $LOG_FILE for full details."


### PR DESCRIPTION
### Summary

This pull request introduces a lightweight enhancement to the script by adding a check for AppArmor status using `apparmor_status`.

### Details

- Adds `apparmor-utils` to the install section (no `sudo`, consistent with existing script style)
- Executes `apparmor_status` during the scan phase
- Helps surface MAC (Mandatory Access Control) status for systems where AppArmor is enabled by default (e.g., Ubuntu)

### Rationale

AppArmor is often active but not visible in basic security checks. Including it improves visibility into kernel-level protections without adding significant overhead.


